### PR TITLE
Add result chart to Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -177,6 +177,10 @@ The measures correspond to the average value of 100 runs of `benchmark.pl`. Sinc
 
 \*\* No GPU acceleration tested.
 
+### Result chart
+
+![Tokenizer performance chart](https://user-images.githubusercontent.com/11092081/169690936-2e5df3c8-bdd3-4c91-bea8-8c8d6800c194.svg)
+
 ## Literature
 
 - Beesley, K. R./Karttunen, L. (2003): Finite State Morphology. CSLI Publications.


### PR DESCRIPTION


With SVG chart produced by performance_chart.R and injected @import for web fonts.

Could also be done automatically via CI workflow pushed to gh-pages or some assets branch, but that would be overkill in this case, I guess, also since the result table is not automatic.

![image](https://user-images.githubusercontent.com/11092081/169692020-aeae3541-789b-4666-a144-28f821dff6b2.png)
